### PR TITLE
update image pk test

### DIFF
--- a/descqa/ImgPkTest.py
+++ b/descqa/ImgPkTest.py
@@ -81,7 +81,7 @@ class ImgPkTest(BaseValidationTest):
         return ax
 
     def plot_psd(self, ax, k, psd, label):
-        ax.loglog(k, psd, label)
+        ax.loglog(k, psd, label=label)
         if self.validation_data is not None:
             ax.loglog(self.validation_data['k'], self.validation_data['Pk'], label=self.validation_data_label)
         ax.set_xlabel('k [arcmin$^{-1}$]')

--- a/descqa/ImgPkTest.py
+++ b/descqa/ImgPkTest.py
@@ -2,16 +2,12 @@ from __future__ import unicode_literals, absolute_import, division
 import os
 import numpy as np
 from scipy.stats import binned_statistic
-import astropy.table
+from astropy.table import Table
 from .base import BaseValidationTest, TestResult
 from .plotting import plt
+from .utils import first, is_string_like
 
 __all__ = ['ImgPkTest']
-
-
-def first(iterable, default=None):
-    return next(iter(iterable), default)
-
 
 class ImgPkTest(BaseValidationTest):
     """
@@ -20,65 +16,114 @@ class ImgPkTest(BaseValidationTest):
 
     Args:
     -----
-    input_path: (str) Directory where the raw e-images live.
-    val_label: (str) Label of the horizontal axis for the validation plots.
-    raft: (str) Raft number to analyze (e.g., 'R01', 'R10', 'R22').
+    raft: str, list of str, or None
+        Raft number to analyze (e.g., 'R01', 'R10', 'R22').
+    rebinning: int, or None
+        rebinning image by this factor
+    validation_data_path: str, or None
+        path to validation data
+    validation_data_label: str
+        label of validation data
+    pixel_scale : float
+        pixel scale  in arcmin
     """
 
-    def __init__(self, input_path, val_label, raft, **kwargs):
+    def __init__(self, raft=None, rebinning=None, validation_data_path=None,
+                 validation_data_label=None, pixel_scale=(0.2/60.0),
+                 **kwargs):
         # pylint: disable=W0231
-        self.input_path = input_path
-        self.validation_data = astropy.table.Table.read(self.input_path)
-        self.label = val_label
         self.raft = raft
+        self.rebinning = rebinning
+        if validation_data_path is None:
+            self.validation_data = None
+        else:
+            self.validation_data = Table.read(validation_data_path)
+        self.validation_data_label = validation_data_label
+        self.pixel_scale = pixel_scale
 
-    def run_on_single_catalog(self, catalog_instance, catalog_name, output_dir):
-        # The catalog instance is a focal plane
-        test_raft = catalog_instance.focal_plane.rafts[self.raft]
-        rebinning = first(test_raft.sensors.values()).rebinning
-        if not rebinning or rebinning < 0:
-            return TestResult(skipped=True, summary='invalid rebinning value: {}'.format(rebinning))
-        if len(test_raft.sensors) != 9:
-            return TestResult(skipped=True, summary='Raft is not complete')
+    def get_rebinning(self, raft):
+        if self.rebinning is None:
+            return first(raft.sensors.values()).default_rebinning
+        return self.rebinning
+
+    def calc_psd(self, raft, bins=300):
+        rebinning = self.get_rebinning(raft)
 
         # Assemble the 3 x 3 raft's image
         # TODO: Need to use LSST's software to handle the gaps properly
-        total_data = np.array([test_raft.sensors['S%d%d'%(i, j)].get_data() for i in range (3) for j in range(3)])
+        total_data = np.array([raft.sensors['S%d%d'%(i,j)].get_data(rebinning=rebinning) for i in range(3) for j in range(3)])
         xdim, ydim = total_data.shape[1:]
         total_data = total_data.reshape(3, 3, xdim, ydim).swapaxes(1, 2).reshape(3*xdim, 3*ydim)
 
         # FFT of the density contrast
         FT = np.fft.fft2(total_data / total_data.mean() - 1)
         n_kx, n_ky = FT.shape
-        psd2D = np.square(np.abs(FT)).ravel() # 2D power, flattened
-        psd2D /= (n_kx * n_ky)
-        pix_scale = 0.2 / 60.0 #pixel scale in arcmin
-        spacing = pix_scale * rebinning
+        spacing = self.pixel_scale * rebinning
+
+        psd2D = np.square(np.abs(FT)).ravel()
+        psd2D *= (spacing / n_kx) * (spacing / n_ky)
+
         rad = np.hypot(*np.meshgrid(np.fft.fftfreq(n_kx, spacing), np.fft.fftfreq(n_ky, spacing), indexing='ij')).ravel()
         rad /= (2.0 * np.pi)
 
-        psd1D, bin_edges, _ = binned_statistic(rad, psd2D, bins=self.validation_data['k'])
+        psd1D, bin_edges, _ = binned_statistic(rad, psd2D, bins=bins)
         bin_center = (bin_edges[1:] + bin_edges[:-1]) * 0.5
-        score = np.square(psd1D/self.validation_data['Pk'][:-1] - 1.0).sum()
+        return bin_center, psd1D
 
-        # make plot
-        fig, ax = plt.subplots(2, 1, figsize=(7, 7))
-        for key, image in test_raft.sensors.items():
-            ax[0].hist(image.get_data().ravel(), histtype='step', range=(200, 2000), bins=200, label=key, log=True)
-        ax[0].set_xlabel('Background level [ADU]')
-        ax[0].set_ylabel('Number of pixels')
-        ax[0].legend(loc='best')
-        ax[1].plot(bin_center, psd1D, label=self.raft)
-        ax[1].plot(self.validation_data['k'], self.validation_data['Pk'], label='validation')
-        ax[1].set_xlabel('k [arcmin$^{-1}$]')
-        ax[1].set_ylabel('P(k)')
-        ax[1].set_xscale('log')
-        ax[1].set_yscale('log')
-        ax[1].set_ylim(1, 1000)
-        ax[1].legend(loc='best')
-        fig.tight_layout()
-        fig.savefig(os.path.join(output_dir, 'plot.png'))
-        plt.close(fig)
+    def plot_hist(self, ax, raft):
+        rebinning = self.get_rebinning(raft)
+        for key, image in raft.sensors.items():
+            ax.hist(image.get_data(rebinning=rebinning).ravel(),
+                    histtype='step', range=(200, 2000), bins=200, label=key, log=True)
+        ax.set_xlabel('Background level [ADU]')
+        ax.set_ylabel('Number of pixels')
+        ax.legend(loc='best')
+        return ax
+
+    def plot_psd(self, ax, k, psd, label):
+        ax.loglog(k, psd, label)
+        if self.validation_data is not None:
+            ax.loglog(self.validation_data['k'], self.validation_data['Pk'], label=self.validation_data_label)
+        ax.set_xlabel('k [arcmin$^{-1}$]')
+        ax.set_ylabel('P(k)')
+        ax.set_xlim(0.001, 2)
+        ax.set_ylim(1.0e-4, 1)
+        ax.legend(loc='best')
+        return ax
+
+    def run_on_single_catalog(self, catalog_instance, catalog_name, output_dir):
+        # The catalog instance is a focal plane
+        rafts = catalog_instance.focal_plane.rafts
+
+        if self.raft is None:
+            raft_names = list(rafts)
+        elif is_string_like(self.raft):
+            raft_names = [self.raft]
+        else:
+            raft_names = list(self.raft)
+
+        if not all(raft_name in rafts for raft_name in raft_names):
+            return TestResult(skipped=True, summary='Not all rafts exist!')
+
+        score = 0
+        count = 0
+        for raft_name in raft_names:
+            raft = rafts[raft_name]
+            fig, ax = plt.subplots(2, 1, figsize=(7, 7))
+            self.plot_hist(ax[0], raft)
+            if len(raft.sensors) == 9:
+                k, psd = self.calc_psd(raft)
+                self.plot_psd(ax[1], k, psd, label=raft_name)
+                if self.validation_data is not None:
+                    psd_log_interp = np.interp(self.validation_data['k'], k, np.log(psd), left=-np.inf, right=-np.inf)
+                    count += 1
+                    score += np.square((psd_log_interp - np.log(self.validation_data['Pk']))).sum()
+            else:
+                print('[Warning] Raft {} is not complete!'.format(raft_name))
+            fig.tight_layout()
+            fig.savefig(os.path.join(output_dir, 'plot_{}.png'.format(raft_name)))
+            plt.close(fig)
+        score /= count
 
         # Check criteria to pass or fail (images in the edges of the focal plane
         # will have way more power than the ones in the center if they are not

--- a/descqa/configs/image_power_spec.yaml
+++ b/descqa/configs/image_power_spec.yaml
@@ -1,7 +1,6 @@
 subclass_name: ImgPkTest.ImgPkTest
-description: 'Compute power spectrum of the background' 
+description: 'Compute power spectrum of the background'
 included_by_default: true
-
-input_path: '/global/projecta/projectdirs/lsst/groups/SSim/DC2/img_pk/Pk_9.fits.gz'
-val_label: 'Test 9'
-raft: 'R22'
+rebinning: 16
+validation_data_path: '/global/projecta/projectdirs/lsst/groups/SSim/DC2/img_pk/Pk_9.fits.gz'
+validation_data_label: 'Test 9'

--- a/descqa/configs/image_power_spec.yaml
+++ b/descqa/configs/image_power_spec.yaml
@@ -2,5 +2,3 @@ subclass_name: ImgPkTest.ImgPkTest
 description: 'Compute power spectrum of the background'
 included_by_default: true
 rebinning: 16
-validation_data_path: '/global/projecta/projectdirs/lsst/groups/SSim/DC2/img_pk/Pk_9.fits.gz'
-validation_data_label: 'Test 9'

--- a/descqa/utils.py
+++ b/descqa/utils.py
@@ -12,6 +12,8 @@ __all__ = [
     'get_healpixel_footprint',
     'generate_uniform_random_ra_dec',
     'generate_uniform_random_ra_dec_footprint',
+    'first',
+    'is_string_like',
 ]
 
 
@@ -233,3 +235,21 @@ def generate_uniform_random_dist(n, dlo, dhi):
     d += dlo**3.0
     d **= 1.0/3.0
     return d
+
+
+def first(iterable, default=None):
+    """
+    returns the first element of `iterable`
+    """
+    return next(iter(iterable), default)
+
+
+def is_string_like(obj):
+    """
+    test if `obj` is string like
+    """
+    try:
+        obj + ''
+    except (TypeError, ValueError):
+        return False
+    return True


### PR DESCRIPTION
@fjaviersanchez I took the liberty to updated the image power spec test, since the changes are not trivial, I am submitting a PR to your PR for you to review.

The main change is to utilize built-in functions, to use `binned_statistic` to simplify the 1d PSD calculation, and to use validation data for the bin edges directly. 

A test run is here: https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-08-27_23 but the web server is down now, so I attach the plot below:

![plot](https://user-images.githubusercontent.com/3792659/44686264-a9898100-aa1b-11e8-8533-c94eeb1e1c32.png)

The power spectrum seems to be much lower than the validation data. Is that expected?